### PR TITLE
Towards 24_STABLE support in mdlrelease

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,8 +2,8 @@
 /.idea/
 /gitmirror/
 /cvsmoodle/
-/cvsmoodle19/
 /cvsmoodle18/
+/cvsmoodle19/
 /cvsmoodle20/
 /cvsmoodle21/
 /cvsmoodle22/

--- a/checkcvsmirror.sh
+++ b/checkcvsmirror.sh
@@ -7,6 +7,8 @@ git merge refs/remotes/origin/master
 cd ..
 diff -ru -I '\$\(Id\|Revision\|RCSfile\|Author\|Date\)[:$]' -x CVS -x .git --strip-trailing-cr gitmirror cvsmoodle
 
+# 2.4 branch - Nah, anymore in CVS, yay!
+
 # 2.3 branch
 cd gitmirror
 git checkout MOODLE_23_STABLE

--- a/cvsmirror.sh
+++ b/cvsmirror.sh
@@ -9,6 +9,8 @@ git merge refs/remotes/origin/master
 cd ..
 /opt/local/bin/php git_to_cvs_mirror.php gitmirror/ cvsmoodle/
 
+#24 branch - Nah, anymore in CVS, yay!
+
 #23 branch
 cd gitmirror
 git checkout MOODLE_23_STABLE

--- a/gitmirror.sh
+++ b/gitmirror.sh
@@ -9,6 +9,7 @@ cd gitmirror
 git fetch origin
 
 git push --tags moodle refs/remotes/origin/master:refs/heads/master
+git push --tags moodle refs/remotes/origin/MOODLE_24_STABLE:refs/heads/MOODLE_24_STABLE
 git push --tags moodle refs/remotes/origin/MOODLE_23_STABLE:refs/heads/MOODLE_23_STABLE
 git push --tags moodle refs/remotes/origin/MOODLE_22_STABLE:refs/heads/MOODLE_22_STABLE
 git push --tags moodle refs/remotes/origin/MOODLE_21_STABLE:refs/heads/MOODLE_21_STABLE
@@ -22,6 +23,7 @@ git push --tags moodle refs/remotes/origin/MOODLE_19_STABLE:refs/heads/MOODLE_19
 # Discontinued - git push --tags moodle refs/remotes/origin/MOODLE_13_STABLE:refs/heads/MOODLE_13_STABLE
 
 git push --tags github refs/remotes/origin/master:refs/heads/master
+git push --tags github refs/remotes/origin/MOODLE_24_STABLE:refs/heads/MOODLE_24_STABLE
 git push --tags github refs/remotes/origin/MOODLE_23_STABLE:refs/heads/MOODLE_23_STABLE
 git push --tags github refs/remotes/origin/MOODLE_22_STABLE:refs/heads/MOODLE_22_STABLE
 git push --tags github refs/remotes/origin/MOODLE_21_STABLE:refs/heads/MOODLE_21_STABLE
@@ -35,6 +37,7 @@ git push --tags github refs/remotes/origin/MOODLE_19_STABLE:refs/heads/MOODLE_19
 # Discontinued - git push --tags github refs/remotes/origin/MOODLE_13_STABLE:refs/heads/MOODLE_13_STABLE
 
 git push --tags gitorious refs/remotes/origin/master:refs/heads/master
+git push --tags gitorious refs/remotes/origin/MOODLE_24_STABLE:refs/heads/MOODLE_24_STABLE
 git push --tags gitorious refs/remotes/origin/MOODLE_23_STABLE:refs/heads/MOODLE_23_STABLE
 git push --tags gitorious refs/remotes/origin/MOODLE_22_STABLE:refs/heads/MOODLE_22_STABLE
 git push --tags gitorious refs/remotes/origin/MOODLE_21_STABLE:refs/heads/MOODLE_21_STABLE

--- a/install_mirror.sh
+++ b/install_mirror.sh
@@ -17,6 +17,7 @@ cd gitmirror
 git remote add moodle $username@git.moodle.org:/git/moodle.git
 git remote add github git@github.com:moodle/moodle.git
 git remote add gitorious git@gitorious.org:moodle/moodle.git
+git branch --track MOODLE_24_STABLE refs/remotes/origin/MOODLE_24_STABLE
 git branch --track MOODLE_23_STABLE refs/remotes/origin/MOODLE_23_STABLE
 git branch --track MOODLE_22_STABLE refs/remotes/origin/MOODLE_22_STABLE
 git branch --track MOODLE_21_STABLE refs/remotes/origin/MOODLE_21_STABLE

--- a/releasemajor.txt
+++ b/releasemajor.txt
@@ -20,6 +20,7 @@ A) STEPS FOR MAJOR RELEASE
 
 $version  = YYYYMMDD00.00; // CHANGEMETORELEASEDATE = branching date YYYYMMDD - do not modify!
 $release  = 'X.Y (Build: YYYYMMDD)';
+$branch   = 'XY';
 $maturity = MATURITY_STABLE;
 
 2) Commit it with message "Moodle release X.Y"
@@ -34,6 +35,7 @@ $maturity = MATURITY_STABLE;
 
 $version  = YYYYMMDD00.00; // YYYYMMDD = weekly release date of this DEV branch
 $release  = 'X.Y+1dev (Build: YYYYMMDD)';
+$branch   = 'XY+1';
 $maturity = MATURITY_ALPHA;
 
 6) Commit it with message "weekly release X.Y+1dev"
@@ -48,29 +50,9 @@ $maturity = MATURITY_ALPHA;
     - cvsmirror.sh
     - checkcvsmirror.sh
 
-10) Verify integration.git looks 100% perfect before continue
+10) Create a new repo, view and jobs (clonig from master) in the Jenkins servers, so the new branch
+    becomes tested by 1st time.
 
-11) Done! A) STEPS Ok. Go back to next step in weeklybuild.txt
+11) Verify integration.git looks 100% perfect before continue
 
-========== ========== ========== ==========
-
-B) STEPS FOR MAJOR RELEASE
-
-
-1) Change to on-demand-master-only mdlrelease branch. Execute
-   all the steps needed to end with CVS HEAD updated (steps 5, 6, 7, 8)
-
-2) Switch back to master mdlrelease branch
-
-3) Duplicate (HEAD) cvsmoodle dir to cvsmoodleXY
-
-4) Ensure you are on HEAD updated: cd cvsmoodleXY ; cvs -q update -dPA
-
-5) Create the MOODLE_XY_STABLE branch: cvs tag -b MOODLE_XY_STABLE
-
-6) cvs update to the new branch: cvs -q update -dPr MOODLE_XY_STABLE
-
-7) Create the new MOODLE_XY_STABLE branch in gitmirror repo:
-    git branch MOODLE_XY_STABLE origin/MOODLE_XY_STABLE
-
-8) Done! B) STEPS Ok. Go back to next step in weeklybuild.txt
+12) Done! A) STEPS Ok. Go back to next step in weeklybuild.txt

--- a/weeklybuild.txt
+++ b/weeklybuild.txt
@@ -45,7 +45,8 @@ A) STEPS FOR MAJOR RELEASE GO HERE!!! (follow them if necessary, step 3 below
 
 4/ Spread changes in integration to moodle.git and mirrors using ./gitmirror.sh
 
-B) STEPS FOR MAJOR RELEASE GO HERE!!! (follow them if necessary)
+NOTE: Steps 5-9 will be out from the process on 20121231 (end of 2012). CVS is death!
+NOTE: There is no MOODLE_24_STABLE branch in CVS since 20121203. So next steps don't apply o it.
 
 5/ be sure that all cvsmoodleXX dirs are updated (cvs -q update -dP)
 
@@ -70,5 +71,8 @@ B) STEPS FOR MAJOR RELEASE GO HERE!!! (follow them if necessary)
 
 10/ close all issues in Tracker (reseting linked MDLQA ones if existing)
 
-11/ add one entry @ http://moodle.org/mod/forum/view.php?f=1153 commenting
+11/ annotate the number of closed issues & the number of reopened ones
+    (Tracker - CI - Count reopened issues) in the sheet.
+
+12/ add one entry @ http://moodle.org/mod/forum/view.php?f=1153 commenting
     about numbers, major ones, special thanks...


### PR DESCRIPTION
This updates the instructions, to get rid
of the CVS stuff for major releases.

Also, updates the shell scripts to handle the
new git branch MOODLE_24_STABLE properly.
