### PR TITLE
MDLSITE-2578 release.sh - no longer can you accidentally release!

### DIFF
--- a/release.sh
+++ b/release.sh
@@ -6,15 +6,147 @@
 # Please note you need to have public ssh keys in all remotes except the origin!
 #
 # This script base dir
+
+# Reset to normal.
+N="$(tput setaf 9)"
+# Red.
+R="$(tput setaf 1)"
+# Green.
+G="$(tput setaf 2)"
+# Yellow.
+Y="$(tput setaf 3)"
+# Cyan.
+C="$(tput setaf 6)"
+bold=`tput bold`
+normal=`tput sgr0`
+_verbose=true # Make lots of noise.
+_showhelp=false
+_confirmed=false
+_dryrun=false
+_tags=true
+
+show_help() {
+    echo ""
+    echo "${bold}Moodle release - release.sh script${normal}"
+    echo ""
+    echo "This tool spreads the already prepared release from integration.git"
+    echo "to moodle.git and then onto the other public repositories we maintain."
+    echo ""
+    echo "${Y}Warning:${normal} Only run this script after you have prepared the release!"
+    echo ""
+    echo "${bold}Usage:${normal}"
+    echo "  ./release.sh [-c|--confirm] [-n|--dry-run] [-q|--quiet] [-h|--help]"
+    echo "               [--no-tags]"
+    echo ""
+    echo "${bold}Arguments:${normal}"
+    echo "  ${bold}-c${normal}, ${bold}--confirm${normal}"
+    echo "      This script requires that you confirm the action you are about to take."
+    echo "      By giving this argument you acknowledge you understand what is going to"
+    echo "      be done and are happy for this script to just get on with it, without"
+    echo "      prompting you to check."
+    echo "  ${bold}-n${normal}, ${bold}--dry-run${normal}"
+    echo "      Do everything except actually send the updates."
+    echo "  ${bold}-q${normal}, ${bold}--quiet${normal}"
+    echo "      If set this script produces no progress output. It'll let you know when "
+    echo "      its finished however."
+    echo "      You must confirm [-c|--confirm] if using this option."
+    echo "  ${bold}-h${normal}, ${bold}--help${normal}"
+    echo "      Prints this help and exits."
+    echo "  ${bold}--no-tags${normal}"
+    echo "      By default tags are pushed as well, this prevents that from happening."
+    echo "      I hope you know what you're doing!"
+    echo ""
+    echo "May the --force be with you"
+    exit 0;
+}
+
+output() {
+    if $_verbose ; then
+        if [ ! -z $2 ]  ; then
+            echo -n "$1"
+        else
+            echo "$1"
+        fi
+    fi
+}
+
+while test $# -gt 0;
+do
+    case "$1" in
+        -c | --confirm)
+            _confirmed=true
+            shift
+            ;;
+        -h | --help)
+            _showhelp=true
+            shift
+            ;;
+        -n | --dry-run)
+            _dryrun=true
+            shift
+            ;;
+        -q | --quiet)
+            _verbose=false
+            shift # Get rid of the flag.
+            ;;
+        --no-tags)
+            _tags=false
+            shift # Get rid of the flag.
+            ;;
+        *)
+            echo "${R}* Invalid option $1 given.${N}"
+            _showhelp=true
+            shift
+    esac
+done
+
+if $_showhelp ; then
+    show_help
+fi
+
 mydir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+if [[ ! -d ${mydir}/gitmirror ]] ; then
+    output "Directory ${mydir}/gitmirror not found. You may need to create it with install.sh"
+    exit 1
+fi
+
+output "${G}Moodle release propogator${N}"
 
 cd ${mydir}/gitmirror
-git fetch origin
+git fetch --quiet origin
+
+if ! $_confirmed ; then
+    if ! $_verbose ; then
+        echo "${R}Error${N}: you must auto-confirm [-c|--confirm] when running silent [-q|--quiet]"
+        exit 1
+    fi
+    output "${bold}Confirm:${normal} please confirm you intention to update the public repositories with the"
+    output "         prepared release: [y|n] " true
+    read -n 1 confirminput
+    if [ "$confirminput" != "y" ] && [ "$confirminput" != "Y" ] ; then
+        output " ... release script ${bold}cancelled${normal}. Have a nice day!"
+        exit 0
+    else
+        output " ... proceeding"
+    fi
+fi
+
+output ""
+output "${bold}Propogating${normal} ... " true
+
+pushargs=""
+if $_tags ; then
+    pushargs="${pushargs} --tags"
+fi
+if $_dryrun ; then
+    pushargs="${pushargs} --dry-run"
+fi
 
 # Update public repositories
 #  * moodle         - git://git.moodle.org/moodle.git
-#  * github         - git://github.com/moodle/moodle.git
-#  * gitorious      - git://github.com/moodle/moodle.git
+#  * github         - git@github.com:moodle/moodle.git
+#  * gitorious      - git@gitorious.org:moodle/moodle.git
+#  * bitbucket      - git@bitbucket.org:moodle/moodle.git
 git push --tags public refs/remotes/origin/master:refs/heads/master \
                         refs/remotes/origin/MOODLE_26_STABLE:refs/heads/MOODLE_26_STABLE \
                         refs/remotes/origin/MOODLE_25_STABLE:refs/heads/MOODLE_25_STABLE \
@@ -24,3 +156,6 @@ git push --tags public refs/remotes/origin/master:refs/heads/master \
 # Discontinued 20130708 - refs/remotes/origin/MOODLE_22_STABLE:refs/heads/MOODLE_22_STABLE \
 # Discontinued 20130114 - refs/remotes/origin/MOODLE_21_STABLE:refs/heads/MOODLE_21_STABLE \
 # Discontinued 20120706 - refs/remotes/origin/MOODLE_20_STABLE:refs/heads/MOODLE_20_STABLE \
+
+output "${G}Done!${N}"
+exit 0


### PR DESCRIPTION
I've added several arguments to the release script to better control things.
I've also pulled in Eloy's change to push from the local repo heads rather than the refs.

The options I've introduced are:
  -c, --confirm
      This script requires that you confirm the action you are about to take.
      By giving this argument you acknowledge you understand what is going to
      be done and are happy for this script to just get on with it, without
      prompting you to check.
  -n, --dry-run
      Do everything except actually send the updates.
  -q, --quiet
      If set this script produces no progress output. It'll let you know when 
      its finished however.
      You must confirm [-c|--confirm] if using this option.
  -h, --help
      Prints this help and exits.
  --no-tags
      By default tags are pushed as well, this prevents that from happening.
      I hope you know what you're doing!

I've not yet tested the actual release or dry-run option - really I am too scared to test it mid-integration.
Best we test this when everything is blue and we're ready to push - that way it if breaks and releases we're not in trouble.

Many thanks
Sam
