### PR TITLE
Removed the security branch from the weekly releases

### DIFF
--- a/prerelease.sh
+++ b/prerelease.sh
@@ -31,7 +31,8 @@ _nocreate=false
 localbuffer=""
 
 # Try to observe the "master first, then stables from older to newer" rule.
-weeklybranches=("master" "MOODLE_23_STABLE" "MOODLE_24_STABLE" "MOODLE_25_STABLE" "MOODLE_26_STABLE");
+# We don't make a weekly release of the security only branch any more. It is however still released during a minor release.
+weeklybranches=("master" "MOODLE_24_STABLE" "MOODLE_25_STABLE" "MOODLE_26_STABLE");
 minorbranches=("MOODLE_23_STABLE" "MOODLE_24_STABLE" "MOODLE_25_STABLE" "MOODLE_26_STABLE");
 majorbranches=("master");
 betabranches=("master");


### PR DESCRIPTION
Simple change to remove the security only branch (23) from the weekly releases.
