### PR TITLE
NOBUG: Suggest to remove existing gitmirror directory

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -36,6 +36,17 @@ else
     exit
 fi
 
+if [ -d gitmirror ]; then
+    read -r -p "Directory gitmirror already exists. Do you agree to remove it? [y/N] " response
+    response="$(tr [A-Z] [a-z] <<< "${response}")"
+    if [[ $response =~ ^(yes|y)$ ]]; then
+        rm -rf gitmirror && echo "Directory removed" || echo "Unable to remove directory gitmirror. Aborting"; exit
+    else
+        echo "Installation cancelled"
+        exit
+    fi
+fi
+
 git clone ${remotei} gitmirror
 cd gitmirror
 


### PR DESCRIPTION
If directory gitmirror already exists, the installation process keep outputting errors:

fatal: destination path 'gitmirror' already exists and is not an empty directory.
fatal: remote public already exists.
fatal: A branch named 'MOODLE_26_STABLE' already exists.
fatal: A branch named 'MOODLE_25_STABLE' already exists.
fatal: A branch named 'MOODLE_24_STABLE' already exists.

This suggests to remove the existing directory before continue with installation
