### PR TITLE
NOBUG: added handling for failed clone operation

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -48,6 +48,14 @@ if [ -d gitmirror ]; then
 fi
 
 git clone ${remotei} gitmirror
+if [[ $? -ge 1 ]] ; then
+    # Drat it failed to clone. I bet you are a remote worker and either forgot to connect to the VPN or forgot to
+    # specify https as the protocol.
+    # Either way the gitmirror directory doesn't exist, we need to exit before we screw up your mdlrelease checkout.
+    echo "Failed to clone the Moodle repository. Check the protocol, ${protocol} used. ($?)"
+    exit 1
+fi
+
 cd gitmirror
 
 # Set a push URL for the origin (integration) remote repository.


### PR DESCRIPTION
Adds a short snippet of code to check the outcome of the git clone operation.
Presently if the clone fails it just carries on, the cd gitmirror fails and then it proceeds to mess up your mdlrelease repository.
I fell for this (has been a long while since I've run install), made the fix, tested it worked and then successfully installed later.
