### PR TITLE
NOBUG: Fix rc transitions

### DIFF
--- a/bumpversions.php
+++ b/bumpversions.php
@@ -145,7 +145,7 @@ function bump_version($path, $branch, $type, $rc = null, $date = null) {
             list($versionmajornew, $versionminornew) = bump_master_ensure_higher($versionmajornew, $versionminornew);
             $maturitynew = 'MATURITY_BETA';
         } else if ($type === 'rc') {
-            $releasenew = preg_replace('#^(\d+.\d+) *(dev|beta)\+?#', '$1', $releasenew);
+            $releasenew = preg_replace('#^(\d+.\d+) *(dev|beta|rc\d)\+?#', '$1', $releasenew);
             $branchnew = str_replace('.', '', $releasenew);
             $releasenew .= 'rc'.$rc;
             list($versionmajornew, $versionminornew) = bump_master_ensure_higher($versionmajornew, $versionminornew);


### PR DESCRIPTION
When moving from rc1+ to rc2, there was a bug
leading to incorrect rc1+rc2 $version. This fixes
it by allowing the rc\d+? => rc\d transitions.
