### PR TITLE
NOBUG: Separated branches out into a config.sh

### DIFF
--- a/config.sh
+++ b/config.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+# This script contains the configuration for the mdlrelease scripts.
+# It only needs to be updated after major releases at the moment as
+# it contains only references to the stable and security branches.
+
+# Current stable branches.
+STABLEBRANCHES=('MOODLE_26_STABLE' 'MOODLE_27_STABLE')
+
+# Current security branches.
+SECURITYBRANCHES=('MOODLE_25_STABLE')

--- a/install.sh
+++ b/install.sh
@@ -4,6 +4,14 @@
 # Please note you need to have public ssh key in all the remotes below (github, gitorious, bitbucket)
 # And also, can decide about the protocol (ssh, https) to be used against moodle main repositories.
 
+# Include config to get access to branch information.
+if [ -f $(dirname $0)/config.sh ]; then
+    source $(dirname $0)/config.sh
+else
+    echo "Unable to include config.sh"
+    exit 1
+fi
+
 protocol=${1:-ssh}
 username=${2:-}
 
@@ -68,12 +76,15 @@ git remote set-url --add --push public git@github.com:moodle/moodle.git
 git remote set-url --add --push public git@gitorious.org:moodle/moodle.git
 git remote set-url --add --push public git@bitbucket.org:moodle/moodle.git
 
-git branch --track MOODLE_26_STABLE refs/remotes/origin/MOODLE_26_STABLE
-git branch --track MOODLE_25_STABLE refs/remotes/origin/MOODLE_25_STABLE
-git branch --track MOODLE_24_STABLE refs/remotes/origin/MOODLE_24_STABLE
-# Discontinued 20140113 - git branch --track MOODLE_23_STABLE refs/remotes/origin/MOODLE_23_STABLE
-# Discontinued 20130708 - git branch --track MOODLE_22_STABLE refs/remotes/origin/MOODLE_22_STABLE
-# Discontinued 20130114 - git branch --track MOODLE_21_STABLE refs/remotes/origin/MOODLE_21_STABLE
-# Discontinued 20120706 - git branch --track MOODLE_20_STABLE refs/remotes/origin/MOODLE_20_STABLE
-# Discontinued 20140113 - git branch --track MOODLE_19_STABLE refs/remotes/origin/MOODLE_19_STABLE
+# Create stable branches with the upstream set.
+for branch in ${STABLEBRANCHES[@]}; do
+    git branch --track ${branch} refs/remotes/origin/${branch}
+done
+
+# Create security branches with the upstream set.
+for branch in ${SECURITYBRANCHES[@]}; do
+    git branch --track ${branch} refs/remotes/origin/${branch}
+done
+
 cd ..
+exit 0

--- a/release.sh
+++ b/release.sh
@@ -7,6 +7,20 @@
 #
 # This script base dir
 
+# Include config to get access to branch information.
+if [ -f $(dirname $0)/config.sh ]; then
+    source $(dirname $0)/config.sh
+else
+    echo "Unable to include config.sh"
+    exit 1
+fi
+
+# Prepare and array of all branches.
+OLDIFS="$IFS"
+IFS=$'\n'
+allbranches=($(for b in "master" "${STABLEBRANCHES[@]}" "${SECURITYBRANCHES[@]}" ; do echo "$b" ; done | sort -du))
+IFS="$OLDIFS"
+
 # Reset to normal.
 N="$(tput setaf 9)"
 # Red.
@@ -142,21 +156,18 @@ if $_dryrun ; then
     pushargs="${pushargs} --dry-run"
 fi
 
+# Prepare an array of all of the branches to push as refs.
+OLDIFS="$IFS"
+IFS=$'\n'
+pushbranches=($(for b in "${allbranches[@]}" ; do echo "refs/remotes/origin/${b}:refs/heads/${b}" ; done))
+IFS="$OLDIFS"
+
 # Update public repositories
 #  * moodle         - git://git.moodle.org/moodle.git
 #  * github         - git@github.com:moodle/moodle.git
 #  * gitorious      - git@gitorious.org:moodle/moodle.git
 #  * bitbucket      - git@bitbucket.org:moodle/moodle.git
-git push ${pushargs} public refs/remotes/origin/master:refs/heads/master \
-                            refs/remotes/origin/MOODLE_27_STABLE:refs/heads/MOODLE_27_STABLE \
-                            refs/remotes/origin/MOODLE_26_STABLE:refs/heads/MOODLE_26_STABLE \
-                            refs/remotes/origin/MOODLE_25_STABLE:refs/heads/MOODLE_25_STABLE
-# Discontinued 20140714 -   refs/remotes/origin/MOODLE_24_STABLE:refs/heads/MOODLE_24_STABLE
-# Discontinued 20140113 -   refs/remotes/origin/MOODLE_23_STABLE:refs/heads/MOODLE_23_STABLE
-# Discontinued 20140113 -   refs/remotes/origin/MOODLE_19_STABLE:refs/heads/MOODLE_19_STABLE
-# Discontinued 20130708 -   refs/remotes/origin/MOODLE_22_STABLE:refs/heads/MOODLE_22_STABLE
-# Discontinued 20130114 -   refs/remotes/origin/MOODLE_21_STABLE:refs/heads/MOODLE_21_STABLE
-# Discontinued 20120706 -   refs/remotes/origin/MOODLE_20_STABLE:refs/heads/MOODLE_20_STABLE
+git push ${pushargs} public ${pushbranches[@]}
 
 output "${G}Done!${N}"
 exit 0


### PR DESCRIPTION
This change introduces a config.sh file that contains arrays of branches to use within the all other scripts rather than the currently definitions in individual scripts.
This change paves way for better branch control - especially within release.sh

I've tested this on an install and have dry-runned prerelease and release.
