### PR TITLE
MDLSITE-3732 release.sh: only push release incremented branches

### DIFF
--- a/release.sh
+++ b/release.sh
@@ -142,9 +142,8 @@ skippedbranches=()
 
 output
 output "${normal}You are about to push:"
-builddate=$(date +%Y%m%d)
 for b in "${allbranches[@]}" ; do
-    versionbumped=$(git show --since='8 hours ago' -n1 origin/${b} version.php | grep "\+\$release\s*=.*$builddate")
+    versionbumped=$(git show --since='8 hours ago' -n1 origin/${b} version.php | grep "\+\$release\s*=\s*")
     if [[ -n ${versionbumped} || $_skip_version_check ]]; then
         pushbranches+=("refs/remotes/origin/${b}:refs/heads/${b}")
         output "${G}$b: ${normal}$(git log -n1 --pretty=format:"%s (%an %ar)" origin/$b)"


### PR DESCRIPTION
Looks like this:
```
./release.sh
Moodle release propogator

You are about to push:
MOODLE_27_STABLE: weekly release 2.7.3+ (Dan Poltawski 3 hours ago)
MOODLE_28_STABLE: weekly release 2.8.1+ (Dan Poltawski 3 hours ago)
master: weekly release 2.9dev (Dan Poltawski 3 hours ago)

Ignoring: MOODLE_26_STABLE  (no version bump detected) 

Confirm: please confirm you intention to update the public repositories with the
         prepared release: [y|n] y ... proceeding

Counting objects: 1500, done.cts: 1275   
Delta compression using up to 8 threads.
Compressing objects: 100% (357/357), done.
Writing objects: 100% (1500/1500), 229.65 KiB | 0 bytes/s, done.
Total 1500 (delta 1176), reused 1423 (delta 1115)
To https://git.in.moodle.com/moodle/moodle.git
   56624fa..3caea82  origin/MOODLE_27_STABLE -> MOODLE_27_STABLE
   440085e..ed46f0d  origin/MOODLE_28_STABLE -> MOODLE_28_STABLE
   eb1dc9f..edbcfbd  origin/master -> master
Counting objects: 1500, done.
Delta compression using up to 8 threads.
Compressing objects: 100% (357/357), done.
Writing objects: 100% (1500/1500), 234.12 KiB | 0 bytes/s, done.
Total 1500 (delta 1174), reused 1423 (delta 1115)
To git@github.com:moodle/moodle.git
   56624fa..3caea82  origin/MOODLE_27_STABLE -> MOODLE_27_STABLE
   440085e..ed46f0d  origin/MOODLE_28_STABLE -> MOODLE_28_STABLE
   eb1dc9f..edbcfbd  origin/master -> master
Counting objects: 1500, done.
Delta compression using up to 8 threads.
Compressing objects: 100% (357/357), done.
Writing objects: 100% (1500/1500), 229.65 KiB | 0 bytes/s, done.
Total 1500 (delta 1176), reused 1423 (delta 1115)
To git@gitorious.org:moodle/moodle.git
   56624fa..3caea82  origin/MOODLE_27_STABLE -> MOODLE_27_STABLE
   440085e..ed46f0d  origin/MOODLE_28_STABLE -> MOODLE_28_STABLE
   eb1dc9f..edbcfbd  origin/master -> master
Counting objects: 1500, done.
Delta compression using up to 8 threads.
Compressing objects: 100% (357/357), done.
Writing objects: 100% (1500/1500), 234.12 KiB | 0 bytes/s, done.
Total 1500 (delta 1174), reused 1423 (delta 1115)
To git@bitbucket.org:moodle/moodle.git
   56624fa..3caea82  origin/MOODLE_27_STABLE -> MOODLE_27_STABLE
   440085e..ed46f0d  origin/MOODLE_28_STABLE -> MOODLE_28_STABLE
   eb1dc9f..edbcfbd  origin/master -> master
Done!
```