### PR TITLE
The + saga continues..

### DIFF
--- a/bumpversions.php
+++ b/bumpversions.php
@@ -146,7 +146,7 @@ function bump_version($path, $branch, $type, $rc = null, $date = null) {
             }
             list($versionmajornew, $versionminornew) = bump_master_ensure_higher($versionmajornew, $versionminornew);
         } else if ($type === 'beta') {
-            $releasenew = preg_replace('#^(\d+.\d+) *(dev)#', '$1', $releasenew);
+            $releasenew = preg_replace('#^(\d+.\d+) *(dev\+?)#', '$1', $releasenew);
             $branchnew = str_replace('.', '', $releasenew);
             $releasenew .= 'beta';
             list($versionmajornew, $versionminornew) = bump_master_ensure_higher($versionmajornew, $versionminornew);


### PR DESCRIPTION
I guess this is caused by e2d7919a very similar to 84171cbc (etc)..

When incrementing the version this time it got borked because our
release name is now 3.1dev+ and you ended up with:

```
diff --git a/version.php b/version.php
[...]
-$release  = '3.1dev+ (Build: 20160429)'; // Human-friendly version name
+$release  = '3.1+beta (Build: 20160504)'; // Human-friendly version name

-$branch   = '31';                       // This version's branch.
-$maturity = MATURITY_ALPHA;             // This version's maturity level.
+$branch   = '31+';                       // This version's branch.
+$maturity = MATURITY_BETA;             // This version's maturity lev

```
And misguided instructions telling you to tag that with the production
tag (ARGHGHHHHHHHHH!!!):

`    git tag -a 'v3.1.0' -m 'MOODLE_31' 8ce725245d449154e181f7d26367b7221a5aa4e4`

With this patch, things [look better](https://git.in.moodle.com/moodle/integration/commit/fc1ef59fbed351ec3de68be4eeec0f3a6cbfe210), and there aren't dangerous instructions:
```

Please propagate these changes to the integration repository with the following:

  git push origin master
  
  git tag -a 'v3.1.0-beta' -m 'MOODLE_31_BETA' fc1ef59fbed351ec3de68be4eeec0f3a6cbfe210

Once CI jobs have ended successfully, you can safely push the release tag(s) to the integration repository:

  git push origin --tags
```