### PR TITLE
NOBUG: Towards last on-sync release leading to version divergence

### DIFF
--- a/README.md
+++ b/README.md
@@ -255,7 +255,7 @@ Spread changes in integration to moodle.git and mirrors using ./release.sh (you 
 ### On sync release
 
 Used to produce an on-sync release for the master branch. This type of release skips all stable branches.
-This release type should only be used when the Moodle's master branch must stay "in sync" with the latest stable branch after a major release.
+This release type should only be used when the Moodle's master branch must stay "in sync" with the latest stable branch after a major release. Note that the last week of the period, when on-sync ends, it's better to perform a normal master release (weekly) in order to guarantee that versions have diverged and avoid potential problems.
 The following steps must be followed to perform an on-sync release.
 
 **1. Run the pre-release script.**

--- a/prerelease.sh
+++ b/prerelease.sh
@@ -793,4 +793,8 @@ if [ $_type == "major" ] || [ $_type == "minor" ]; then
     fi
     echo "  - Follow the ${R}instructions and steps order${N} for major and minor releases @ https://docs.moodle.org/dev/Release_process#Packaging."
     echo ""
+elif [ $_type == "on-sync" ]; then
+    echo "${Y}Notes${N}: "
+    echo "  - Don't forget that ${R}the last week of on-sync${N} it's better to perform a ${R}normal master release (weekly)${N} in order to guarantee that versions have diverged. If this is such a week, please proceed accordingly."
+    echo ""
 fi


### PR DESCRIPTION
Just to complete what already is documented in the release process, both README and prerelease.sh make a call about to perform a weekly when on-sync is ending.