### PR TITLE
Initial support for multiple development branches

### DIFF
--- a/config.sh
+++ b/config.sh
@@ -3,6 +3,9 @@
 # It only needs to be updated after major releases at the moment as
 # it contains only references to the stable and security branches.
 
+# Current dev branches (always keep master the first).
+DEVBRANCHES=('master' 'MOODLE_310_STABLE')
+
 # Current stable branches.
 STABLEBRANCHES=('MOODLE_38_STABLE' 'MOODLE_39_STABLE')
 

--- a/release.sh
+++ b/release.sh
@@ -18,7 +18,7 @@ fi
 # Prepare and array of all branches.
 OLDIFS="$IFS"
 IFS=$'\n'
-allbranches=($(for b in "master" "${STABLEBRANCHES[@]}" "${SECURITYBRANCHES[@]}" ; do echo "$b" ; done | sort -du))
+allbranches=($(for b in "${DEVBRANCHES[@]}" "${STABLEBRANCHES[@]}" "${SECURITYBRANCHES[@]}" ; do echo "$b" ; done | sort -du))
 IFS="$OLDIFS"
 
 # Reset to normal.


### PR DESCRIPTION
This comes from [MDLSITE-6218](https://tracker.moodle.org/browse/MDLSITE-6218)

Supports:
- configure which the dev branches are.
- release weeklies properly.
- release minors properly.

TODO ([MDLSITE-6223](https://tracker.moodle.org/browse/MDLSITE-6223))
- implement all the TODOs in the scripts.
- verify all the release types.