### PR TITLE
Fix problem when calculating the name of lang strings install branches

### DIFF
--- a/prerelease.sh
+++ b/prerelease.sh
@@ -684,7 +684,9 @@ for branch in ${branches[@]};
             output "${Y}Skipping $branch as it's a minor release.${N}"
             continue
         fi
-        mergestringsbranch="install_$branch"
+        # Get the segment of the stable branch name to use for merges.
+        stable=`expr "$branch" : 'MOODLE_'`
+        mergestringsbranch="install_${branch:$stable}"
     else
         # Must be a stable branch.
         # Stable branches are not included in major, beta, or rc releases.


### PR DESCRIPTION
There was a problem when calculating the name of the lang strings
intall branches affecting to DEV branches (for STABLE braches it
was working ok).

That's the reason MOODLE_310_STABLE did the work ok and it
correctly found the install_310_STABLE branch.

But MOODLE_311_STABLE, that is a DEV branch (despite its name) was
calculating the name like: install_MOODLE_311_STABLE that doesn't
exist.

We were missing to remove that "MOODLE_" from the name. Never noticed
this because for master (our other DEV branch, it works ok, because
it doesn't have any MOODLE_).