### PR TITLE
Add the new mimetex.linux.aarch64 to be handled as binary /executable

### DIFF
--- a/fixpermissions.php
+++ b/fixpermissions.php
@@ -71,11 +71,12 @@ $gitignore    = array('.gitignore', '.cvsignore', '.settings', '.buildpath', '.p
 /* List of moodle files that are supposed to be executable */
 
 $executables = array(
-    'filter/tex/mimetex.linux',
-    'filter/tex/mimetex.freebsd',
     'filter/tex/mimetex.darwin',
+    'filter/tex/mimetex.exe',
+    'filter/tex/mimetex.freebsd',
+    'filter/tex/mimetex.linux',
+    'filter/tex/mimetex.linux.aarch64',
     'filter/algebra/algebra2tex.pl',
-    'filter/tex/mimetex.exe'
     // filter/tex/mimetex.exe added to avoid problems running unit tests in Windows (MDL-47648)
     // do not include 'lib/editor/tinymce/extra/tools/download_langs.sh' here because it is used by devs only
 


### PR DESCRIPTION
In MDL-70627 we introduced a new mimetex binary, and it was added with
755 permissions (I remember it pretty well because I amended the
original commit to add the executable bits).

But that new file was not known to our beloved prerelease stuff, so
perms were changed back to 644. See https://github.com/moodle/moodle/commit/3122b30050c639

This commit just adds the new binary, and also sorts them alphabetically
for easier reading.

To test this, just run mdlrelease and verify that a new commit, moving the file from 644 => 755 is generated (311 & master). I've 😄 !