### PR TITLE
Avoid any branch change on beta/rc/major

### DIFF
--- a/bumpversions.php
+++ b/bumpversions.php
@@ -147,14 +147,14 @@ function bump_version($path, $branch, $type, $rc, $date, $isdevbranch) {
             }
             list($versionmajornew, $versionminornew) = bump_dev_ensure_higher($versionmajornew, $versionminornew);
         } else if ($type === 'beta') {
-            $releasenew = preg_replace('#^(\d+.\d+) *(dev\+?)#', '$1', $releasenew);
-            $branchnew = str_replace('.', '', $releasenew);
+            $releasenew = preg_replace('#^(\d+.\d+) *(dev|beta)\+?#', '$1', $releasenew);
+            $branchnew = $branchcurrent; // Branch doesn't change in beta releases ever.
             $releasenew .= 'beta';
             list($versionmajornew, $versionminornew) = bump_dev_ensure_higher($versionmajornew, $versionminornew);
             $maturitynew = 'MATURITY_BETA';
         } else if ($type === 'rc') {
             $releasenew = preg_replace('#^(\d+.\d+) *(dev|beta|rc\d)\+?#', '$1', $releasenew);
-            $branchnew = str_replace('.', '', $releasenew);
+            $branchnew = $branchcurrent; // Branch doesn't change in rc releases ever.
             $releasenew .= 'rc'.$rc;
             list($versionmajornew, $versionminornew) = bump_dev_ensure_higher($versionmajornew, $versionminornew);
             $maturitynew = 'MATURITY_RC';
@@ -187,7 +187,7 @@ function bump_version($path, $branch, $type, $rc, $date, $isdevbranch) {
         } else {
             // Awesome major release!
             $releasenew = preg_replace('#^(\d+.\d+) *(dev|beta|rc\d+)\+?#', '$1', $releasenew);
-            $branchnew = str_replace('.', '', $releasenew);
+            $branchnew = $branchcurrent; // Branch doesn't change in major releases ever.
             list($versionmajornew, $versionminornew) = bump_dev_ensure_higher($versionmajornew, $versionminornew);
             $maturitynew = 'MATURITY_STABLE';
             // Now handle builddate for releases.


### PR DESCRIPTION
With the release of 4.0beta it has been detected that
we were re-calculating the branch on beta/rc/major
releases, and it's not needed at all (the branch never
changes on those releases).

So this commit just keeps it unmodified for those releases.

Also, a small change has been performed to the beta regexp
in order to avoid creating 4.0betabeta (double betas). This
doesn't happen ever (we only release ONE beta), but testing
discovered that we were concatenating incorrectly.

Finally, note that there is one more case to review, not part of
this PR, that is when, on release date, we change the branch
in master from 400 to 401. I'm working on that one now and will
provide a separate PR with that fixed.

To test this just run: ./prerelease --type [beta|rc X|major] and ensure that all them lead to correct changes (use the --show option to see them). Of course, don't push or do any git operation. heh.

Ciao :-)