### PR TITLE
Prepare major and back-to-dev release types to 400

### DIFF
--- a/bumpversions.php
+++ b/bumpversions.php
@@ -172,11 +172,14 @@ function bump_version($path, $branch, $type, $rc, $date, $isdevbranch) {
             if (strpos($releasecurrent, 'dev') === false) { // Ensure it's not a "dev" version already.
                 // Must be immediately after a major release. Bump comment, release and maturity.
                 $commentnew = '// YYYYMMDD      = weekly release date of this DEV branch.';
-                // TODO: Wrong assumption. Change this (increase by 1 the decimal part for release and ensure branch has 3cc.
-                // We use + 0.1, because after X.9 we jump to (X+1).0.
-                $releasenew = number_format((float)($releasenew + 0.1), 1);
-                $branchnew = str_replace('.', '', $releasenew);
-                $releasenew = $releasenew.'dev';
+                // Normalise a little bit the release, getting rid of everything after the numerical part.
+                $releasenew = preg_replace('/^([0-9.]+).*$/', '\1', $releasenew);
+                // Split the major and minor parts of the release for further process.
+                list($releasemajor, $releaseminor) = explode('.', $releasenew);
+                $releasenew = $releasemajor . '.' . (++$releaseminor); // Increment to next dev version.
+                $releasenew = $releasenew . 'dev';
+                // The branch is the major followed by 2-chars minor.
+                $branchnew = $releasemajor . str_pad($releaseminor, 2, '0', STR_PAD_LEFT);
                 $maturitynew = 'MATURITY_ALPHA';
                 if (empty($date)) { // If no date has been forced, back-to-dev have same build date than majors.
                     if ((int)date('N') !== 1) { // If today is not Monday, calculate next one.

--- a/prerelease.sh
+++ b/prerelease.sh
@@ -237,6 +237,9 @@ get_release_tag_annotation() {
     if [[ rc -gt 0 ]] ; then
         forth="_RC$rc"
     fi
+    if [[ second -lt 10 ]] ; then
+        second="0${second}"
+    fi
     echo "MOODLE_$first$second$third$forth"
 }
 
@@ -265,6 +268,9 @@ get_release_tag_version() {
 get_new_stable_branch() {
     local first=`expr match "$1" '\([0-9]\+\)'`
     local second=`expr match "$1" '[0-9]\+\.\([0-9]\+\)'`
+    if [[ second -lt 10 ]] ; then
+        second="0${second}"
+    fi
     echo "MOODLE_${first}${second}_STABLE"
 }
 output() {
@@ -828,7 +834,7 @@ echo ""
 if [ $_type == "major" ] || [ $_type == "minor" ]; then
     if [ $_type == "major" ] ; then
         echo "${Y}Notes${N}: "
-        if [ ${#devbranches[@]} > 1 ]; then
+        if [ ${#devbranches[@]} -gt 1 ]; then
             echo "  - This has been a major release ${R}under parallel development${N}. It implies that the"
             echo "    STABLE branch released already existed, hence no new branch has been created by this tool."
             echo "    - Important: If the parallel development period is going to continue with a new STABLE branch and master"
@@ -849,5 +855,17 @@ elif [ $_type == "on-sync" ]; then
     echo "${Y}Notes${N}: "
     echo "  - Don't forget that ${R}the last week of on-sync${N} it's better to perform a ${R}normal master release (weekly)${N} in order to guarantee that versions have diverged. If this is such a week, please proceed accordingly."
     echo "  - IMPORTANT: If this is ${R}the last week of on-sync${N}, don't forget to disable the Continuous queues manager job (link: https://ci.moodle.org/view/Tracker/job/TR%20-%20Manage%20queues%20on%20continuous/) to prevent it to continue processing issues once on-sync is finished."
+    echo ""
+elif [ $_type == "back-to-dev" ]; then
+    echo "${Y}Notes${N}: "
+    echo "  - This is a "back-to-dev" release. And it's the ${R}unique type of release${N}"
+    echo "    ${R}effectively incrementing the "\$release" and "\$branch" in the main version.php file${N}."
+    echo ""
+    echo "    Triple ensure that both variables are correct for the next planned major. It may be that you"
+    echo "    want to jump to the next X+1.00 version instead of continue the X series. For example,"
+    echo "    after release 7.23... you may want to jump to 8.0 instead of the, calculated by default, 7.24."
+    echo ""
+    echo "    If that's the case, please ${R}amend the commit manually to make both "\$release"${N}"
+    echo "    ${R}and "\$branch" to point to the correct next major planned release${N}."
     echo ""
 fi


### PR DESCRIPTION
This is the first time that we are going to release
a new two-digits (00) major release. Till now we have
only released 310 and 311 that was continuous from
previous 39 ones.

This implies a little changes to both the "major" and
the "back-to-dev" release types.

On major:
 - We fix how the new branch (MOODLE_400_STABLE) and the
   tag description (MOODLE_400) are calculated. Previously
   they were being calculated as "40" instead of correct "400".

On back-to-dev:
 - We fix how the next development $release (4.1dev) and the
   next development $branch (401) are calculated. This also fixes
   a long standing TODO forever, so versions > .10 will work ok
   automatically.
 - We add a note warning that it's always needed to check the results
   are the correct ones because mdlrelease always just increment by 1
   the calculated versions. And, sometimes, when the next release is
   going to be a new .0 one (for example 4.7 => 5.0) the changes
   need to be done manually.