### PR TITLE
Fix Continuous queues manager job link

### DIFF
--- a/README.md
+++ b/README.md
@@ -377,7 +377,7 @@ there is an optional argument *-p* which if specified pushes the updated branche
 
 Note that the **last week of on-sync**, it's better to perform a normal master release (weekly) in order to guarantee that versions have diverged. If this is such a week, please proceed accordingly.
 
-**IMPORTANT:** If this is the **last week of on-sync**, don't forget to disable the [Continuous queues manager job](https://  ci.moodle.org/view/Tracker/job/TR%20-%20Manage%20queues%20on%20continuous/) right now to prevent it to continue processing issues once on-sync is finished.
+**IMPORTANT:** If this is the **last week of on-sync**, don't forget to disable the [Continuous queues manager job](https://ci.moodle.org/view/Tracker/job/TR%20-%20Manage%20queues%20on%20continuous/) right now to prevent it to continue processing issues once on-sync is finished.
 
 
 **2. Review the branches very carefully.**


### PR DESCRIPTION
Remove the incorrect extra spaces in the Continuous queues manager job link