### PR TITLE
Remind about the need to enable back the security rebaser jobs

### DIFF
--- a/prerelease.sh
+++ b/prerelease.sh
@@ -850,6 +850,7 @@ if [ $_type == "major" ] || [ $_type == "minor" ]; then
         fi
     fi
     echo "  - Follow the ${R}instructions and steps order${N} for major and minor releases @ https://docs.moodle.org/dev/Release_process#Packaging."
+    echo "  - If the ${R}'Rebase security branch'${N} jobs have been disabled (as part of the security2integration task), now it's time to enable them back, so they catch up with current code and are ready for next week. The ${R}'MAINT - Toggle (enable, disable) jobs by name'${N} @ CI job can be used to do that."
     echo ""
 elif [ $_type == "on-sync" ]; then
     echo "${Y}Notes${N}: "


### PR DESCRIPTION
Both on minor and major releases, if the rebaser jobs have been disabled (as per the "Security repository docs" step #8), now it's time to enable them back to everything catches up with current code and security.git is ready to accept new issues.

Now, the `prerelease.sh` execution looks like this, and the added information is displayed both for minors and majors:

```
...
Pre-release processing has been completed.

Changes can be reviewed using the --show option.

Please propagate these changes to the integration repository with the following:

  git push origin MOODLE_311_STABLE MOODLE_39_STABLE MOODLE_401_STABLE MOODLE_400_STABLE
  
  git tag -a 'v3.11.13' -m 'MOODLE_31113' 52ce258a54cc979589fe0551771ac39f10bff9f9
  git tag -a 'v3.9.20' -m 'MOODLE_30920' 899eb07add366876cd1cb8b48076690f061c1bba
  git tag -a 'v4.1.2' -m 'MOODLE_4012' a7b81a1734802d741a978a380a7bc3216db4a0a9
  git tag -a 'v4.0.7' -m 'MOODLE_4007' 268c84326d2fbf9b9be8c8add7e26d5e4f847c4f

Once CI jobs have ended successfully, you can safely push the release tag(s) to the integration repository:

  git push origin --tags

  - Follow the instructions and steps order for major and minor releases @ https://docs.moodle.org/dev/Release_process#Packaging.
  - If the 'Rebase security branch' jobs have been disabled (as part of the security2integration task), now it's time to enable them back, so they catch up with current code and are ready for next week. The 'MAINT - Toggle (enable, disable) jobs by name' @ CI can be used to do that.
```

![rebaser_to_be_enabled](https://user-images.githubusercontent.com/167147/223656458-d124e0d4-83b9-4f45-943f-59f057950646.png)

Ciao :-)