### PR TITLE
Remove unnecessary backslash

### DIFF
--- a/release.sh
+++ b/release.sh
@@ -144,7 +144,7 @@ output
 output "${normal}You are about to push:"
 for b in "${allbranches[@]}" ; do
     # Search for a 'real' release by ensuring the top commit on version.php changes $release and was recent.
-    releasebumped=$(git show --since='8 hours ago' -n1 origin/${b} version.php | grep "\+\$release\s*=\s*")
+    releasebumped=$(git show --since='8 hours ago' -n1 origin/${b} version.php | grep "+\$release\s*=\s*")
     if [[ -n ${releasebumped} || $_skip_version_check ]]; then
         pushbranches+=("refs/remotes/origin/${b}:refs/heads/${b}")
         output "${G}$b: ${normal}$(git log -n1 --pretty=format:"%s (%an %ar)" origin/$b)"


### PR DESCRIPTION
Since grep 3.8.0 it warns about not needed backslash escaping.

Certainly this is one of them. That leading "+" (without anything before) cannot be confused with the "+" (one or more). Because it has nothing before it.

So the backslash is not needed there.

Source: https://salsa.debian.org/debian/grep/-/blob/958bcc3adac8bf8a0f8290ea855f9b4e4d445a1b/NEWS

> Regular expressions with stray backslashes now cause warnings, as their unspecified behavior can lead to unexpected results. For example, '\a' and 'a' are not always equivalent <https://bugs.gnu.org/39678>.  Similarly, regular expressions or subexpressions that start with a repetition operator now also cause warnings due to their unspecified behavior; for example, *a(+b|{1}c) now has three reasons to warn.  The warnings are intended as a transition aid; they are likely to be errors in future releases.