### PR TITLE
Ensure that major releases are always .00

### DIFF
--- a/bumpversions.php
+++ b/bumpversions.php
@@ -209,6 +209,7 @@ function bump_version($path, $branch, $type, $rc, $date, $isdevbranch) {
             } else {
                 $versionmajornew = $date . '00'; // Apply $date also to major versions.
             }
+            $versionminornew = '00'; // Majors always have the decimal reset to .00.
         }
     }
 


### PR DESCRIPTION
There was an edge case where the majors could
be released as .01. This commit just ensures they
are always "next monday" + .00