### PR TITLE
Move from master to main everywhere

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,15 +91,15 @@ Release types
 
 There are several different types of release that can be made by this tool. In fact it covers all of the planned release types.
 
-**Weekly release** - the most common release, made every week and containing all the newly integrated work. Includes master and all stables branches.
+**Weekly release** - the most common release, made every week and containing all the newly integrated work. Includes main and all stables branches.
 
 **Minor release** - every two to three months we make a minor release, this release type handles everything involved with that. Only stable branches are worked on here.
 
-**Beta release** - Around a month or two before a major release we create a beta release of the master branch. This usually occurs when QA testing starts and only affects the master branch.
+**Beta release** - Around a month or two before a major release we create a beta release of the main branch. This usually occurs when QA testing starts and only affects the main branch.
 
-**RC release** - The release candidate release. Usually one or more release candidate releases are prepared for the master branch in the final lead up to the major release. Again master only.
+**RC release** - The release candidate release. Usually one or more release candidate releases are prepared for the main branch in the final lead up to the major release. Again main only.
 
-**Major release** - twice a year we make a major release (and usually a minor release of stables at the same time). This affects only the master branch although it leads to the next stable branch being produced.
+**Major release** - twice a year we make a major release (and usually a minor release of stables at the same time). This affects only the main branch although it leads to the next stable branch being produced.
 
 There are also a handful of advanced release types. These release types are usually very specific and you may - or may not be required to run them. As such they are unplanned and usually only required if the situation demands it.
 
@@ -149,7 +149,7 @@ Follow the [After the release](#after-the-release) steps where needed.
 **Note:** Minor releases are usually produced on the weekend, a **normal weekly** is produced for stable supported branches on the weekdays before it.
 
 The following steps must be followed to perform a minor release.
-The minor release affects all stable branches, master however is skipped as you cannot produce a minor release on an unreleased branch.
+The minor release affects all stable branches, main however is skipped as you cannot produce a minor release on an unreleased branch.
 
 **1. Run the pre-release script.**
 
@@ -179,7 +179,7 @@ Follow the [After the release](#after-the-release) steps where needed. Then, con
 ### Beta release
 
 The following steps must be followed to perform a beta release.
-The beta release puts the master branch into a beta state. This usually happens in conjunction with QA testing, however it can happen any time we feel the master branch is maturing + stabilising in the lead up to a major release. Stable branches are skipped of course.
+The beta release puts the main branch into a beta state. This usually happens in conjunction with QA testing, however it can happen any time we feel the main branch is maturing + stabilising in the lead up to a major release. Stable branches are skipped of course.
 
 **0. Ensure that we have achieved true roll-ability**
 
@@ -192,10 +192,10 @@ Only possible when:
 
     ./prerelease.sh --type beta
 
-Note that we might want to release stable branches together with a master beta, if that is the case we use the following command instead:
+Note that we might want to release stable branches together with a main beta, if that is the case we use the following command instead:
 
     ./prerelease.sh --type weekly
-    # Overwrite weekly master branch with a master beta.
+    # Overwrite weekly main branch with a main beta.
     ./prerelease.sh --type beta
 
 By default this script prepares the branches and gives you the commands to push. It doesn't actually push up to the integration server.
@@ -222,7 +222,7 @@ Follow the [After the release](#after-the-release) steps where needed.
 ### RC release
 
 The following steps must be followed to perform a release candidate release.
-There can be one or more release candidate releases made as the final build up to a major release. They signify that we believe master branch is now stable and that we don't expect to find any more significant issues before release. We have usually addressed all QA related issues and release blocking issues. Again master only.
+There can be one or more release candidate releases made as the final build up to a major release. They signify that we believe main branch is now stable and that we don't expect to find any more significant issues before release. We have usually addressed all QA related issues and release blocking issues. Again main only.
 
 **0. Ensure that we have achieved true roll-ability**
 
@@ -237,10 +237,10 @@ Only possible when:
 
 Where 2 is the release candidate version.
 
-Note that we might want to release stable branches together with a master RC, if that is the case we use the following command instead:
+Note that we might want to release stable branches together with a main RC, if that is the case we use the following command instead:
 
     ./prerelease.sh --type weekly
-    # Overwrite weekly master branch with a master RC.
+    # Overwrite weekly main branch with a main RC.
     ./prerelease.sh --type rc 2
 
 By default this script prepares the branches and gives you the commands to push. It doesn't actually push up to the integration server.
@@ -267,7 +267,7 @@ Follow the [After the release](#after-the-release) steps where needed.
 ### Major release
 
 The following steps must be followed to perform a major release.
-Hurrah - we are ready for a major release, a twice yearly occasion normally. This will take the master branch only, produce a major release, and then create the next stable branch.
+Hurrah - we are ready for a major release, a twice yearly occasion normally. This will take the main branch only, produce a major release, and then create the next stable branch.
 After running this release type you will be required to edit these scripts and add a reference to the newly created stable release so that it is included in the processes here-after.
 
 **1. Run the pre-release script.**
@@ -285,7 +285,7 @@ Add support for the new branch in install.sh, prerelease.sh, and release.sh
 
 **4. Prepare the current integration server**
 
-Create a new repo, view and jobs (cloning from master) in the Jenkins servers, so the new branch becomes tested by 1st time.
+Create a new repo, view and jobs (cloning from main) in the Jenkins servers, so the new branch becomes tested by 1st time.
 
 **5. Double check everything.**
 
@@ -306,7 +306,7 @@ The following advanced release types are also available.
 
 ### On demand release
 
-Used to produce an on-demand release for the master branch. This type of release skips all stable branches.
+Used to produce an on-demand release for the main branch. This type of release skips all stable branches.
 The following steps must be followed to perform an on-demand release.
 
 **0. Ensure that we have achieved true roll-ability**
@@ -320,10 +320,10 @@ Only possible when:
 
     ./prerelease.sh --type on-demand
 
-Note that most of the time we also release stable branches together with a master on-demand, if that is the case we use the following command instead:
+Note that most of the time we also release stable branches together with a main on-demand, if that is the case we use the following command instead:
 
     ./prerelease.sh --type weekly
-    # Overwrite weekly master branch with an on-demand master.
+    # Overwrite weekly main branch with an on-demand main.
     ./prerelease.sh --type on-demand
 
 Also, note that every on-demand release adds unconditionally the plus ('+') at the end of the version, so these changes are expected and normal: dev => dev+, beta => beta+, rc1 => rc1+ ...
@@ -351,8 +351,8 @@ Follow the [After the release](#after-the-release) steps where needed.
 
 ### On sync release
 
-Used to produce an on-sync release for the master branch. This type of release skips all stable branches.
-This release type should only be used when the Moodle's master branch must stay "in sync" with the latest stable branch after a major release. Note that the last week of the period, when on-sync ends, it's better to perform a normal master release (weekly) in order to guarantee that versions have diverged and avoid potential problems.
+Used to produce an on-sync release for the main branch. This type of release skips all stable branches.
+This release type should only be used when the Moodle's main branch must stay "in sync" with the latest stable branch after a major release. Note that the last week of the period, when on-sync ends, it's better to perform a normal main release (weekly) in order to guarantee that versions have diverged and avoid potential problems.
 The following steps must be followed to perform an on-sync release.
 
 **0. Ensure that we have achieved true roll-ability**
@@ -366,16 +366,16 @@ Only possible when:
 
     ./prerelease.sh --type on-sync
 
-Note that most of the time we also release stable branches together with a master on-sync, if that is the case we use the following command instead:
+Note that most of the time we also release stable branches together with a main on-sync, if that is the case we use the following command instead:
 
     ./prerelease.sh --type weekly
-    # Overwrite weekly master branch with an on-sync master.
+    # Overwrite weekly main branch with an on-sync main.
     ./prerelease.sh --type on-sync
 
 By default this script prepares the branches and gives you the commands to push. It doesn't actually push up to the integration server.
 there is an optional argument *-p* which if specified pushes the updated branches to the integration repository.
 
-Note that the **last week of on-sync**, it's better to perform a normal master release (weekly) in order to guarantee that versions have diverged. If this is such a week, please proceed accordingly.
+Note that the **last week of on-sync**, it's better to perform a normal main release (weekly) in order to guarantee that versions have diverged. If this is such a week, please proceed accordingly.
 
 **IMPORTANT:** If this is the **last week of on-sync**, don't forget to disable the [Continuous queues manager job](https://ci.moodle.org/view/Tracker/job/TR%20-%20Manage%20queues%20on%20continuous/) right now to prevent it to continue processing issues once on-sync is finished.
 
@@ -401,7 +401,7 @@ Follow the [After the release](#after-the-release) steps where needed.
 ### Back to dev release
 
 Used to produce a back-to-dev release after a major release.
-This release type should only be used immediately after a major release has been successfully completed in order to set the master branch back to a development state.
+This release type should only be used immediately after a major release has been successfully completed in order to set the main branch back to a development state.
 The following steps must be followed to perform an on-sync release.
 
 **1. Run the pre-release script.**

--- a/bumpversions.php
+++ b/bumpversions.php
@@ -263,7 +263,7 @@ function branch_is_stable($branch, $isdevbranch) {
 }
 
 function validate_branch($branch) {
-    if (!preg_match('#^(master|MOODLE_(\d+)_STABLE)$#', $branch, $matches)) {
+    if (!preg_match('#^(main|MOODLE_(\d+)_STABLE)$#', $branch, $matches)) {
         throw new Exception('Invalid branch given', __LINE__);
     }
     return true;

--- a/config.sh
+++ b/config.sh
@@ -3,8 +3,8 @@
 # It only needs to be updated after major releases at the moment as
 # it contains only references to the stable and security branches.
 
-# Current dev branches (always keep master the first).
-DEVBRANCHES=('master')
+# Current dev branches (always keep main the first).
+DEVBRANCHES=('main')
 
 # Current stable branches. (Later versions first)
 STABLEBRANCHES=('MOODLE_403_STABLE' 'MOODLE_402_STABLE' 'MOODLE_401_STABLE')

--- a/prerelease.sh
+++ b/prerelease.sh
@@ -119,10 +119,10 @@ bump_version() {
         # It's a on-sync release... easy too!
         onsync=true
     elif [ "$2" ==  "back-to-dev" ] ; then
-        # Just returning master to dev after major
+        # Just returning main to dev after major
         backtodev=true
-    elif [ "$1" == "master" ] && [ "$2" == "minor" ] ; then
-        # It's the master branch and a minor release - master just gets a weekly.
+    elif [ "$1" == "main" ] && [ "$2" == "minor" ] ; then
+        # It's the main branch and a minor release - main just gets a weekly.
         weekly=true
     fi
 
@@ -146,7 +146,7 @@ bump_version() {
                 local tagannotation=`get_release_tag_annotation "$release"` # MOODLE_26
                 local taghash=`git_last_commit_hash` # The full git commit hash for the last commit on the branch
 
-                if [ "$1" == "master" ] && [ "$2" == "major" ] ; then
+                if [ "$1" == "main" ] && [ "$2" == "major" ] ; then
                     # Exciting!
 
                     # Calculate new branch name.
@@ -170,7 +170,7 @@ bump_version() {
 
                     # Now we can proceed to branch safely.
                     output "  - Creating new stable branch $newbranch"
-                    git branch -f "$newbranch" master # create from (or reset to) master
+                    git branch -f "$newbranch" main # create from (or reset to) main
 
                     integrationpush="$integrationpush $newbranch"
                 fi
@@ -320,11 +320,11 @@ show_help() {
     echo "  ${bold}./prerelease.sh${normal} runs a standard weekly release"
     echo "  ${bold}./prerelease.sh -b MOODLE_19_STABLE${normal} runs a weekly release for one branch"
     echo "  ${bold}./prerelease.sh -t minor${normal} runs a minor release"
-    echo "  ${bold}./prerelease.sh -t major${normal} runs a major release for master only"
-    echo "  ${bold}./prerelease.sh -t beta${normal} runs a beta release for master only"
-    echo "  ${bold}./prerelease.sh -t rc 2${normal} runs a release for rc2 for master only"
-    echo "  ${bold}./prerelease.sh -t on-demand${normal} runs a weekly on-demand (pre-release) for master only"
-    echo "  ${bold}./prerelease.sh -t on-sync${normal} runs a weekly on-sync (post-release) for master only"
+    echo "  ${bold}./prerelease.sh -t major${normal} runs a major release for main only"
+    echo "  ${bold}./prerelease.sh -t beta${normal} runs a beta release for main only"
+    echo "  ${bold}./prerelease.sh -t rc 2${normal} runs a release for rc2 for main only"
+    echo "  ${bold}./prerelease.sh -t on-demand${normal} runs a weekly on-demand (pre-release) for main only"
+    echo "  ${bold}./prerelease.sh -t on-sync${normal} runs a weekly on-sync (post-release) for main only"
     exit 0
 }
 
@@ -538,22 +538,22 @@ fi
 branches=()
 
 # If the release is a major-related one, and no branch has been forced, and we are under parallel development
-# let's pick the best default branch (first non-master one).
+# let's pick the best default branch (first non-main one).
 if in_array "$_type" "${_reltypes[@]}" && [ -z $_onlybranch ] && [ ${#devbranches[@]} -gt 1 ] ; then
     # There isn't any back-to-dev under parallel development. Next branch needs to
-    # be created manually (if parallel continues), or is master that is already dev (if parallel ends).
+    # be created manually (if parallel continues), or is main that is already dev (if parallel ends).
     if [ "$_type" == "back-to-dev" ] ; then
         output "Invalid type \"back-to-dev\" specified under parallel development.";
         exit 1
     fi
-    # The best branch when there are multiple is always the nearest to be released, usually the 1st non-master one.
+    # The best branch when there are multiple is always the nearest to be released, usually the 1st non-main one.
     output "  - Major release related \"${_type}\" type detected under parallel development."
     output "  - Calculating the development branch to apply the changes to (note that"
     output "    this can be overridden using the --branch option to force a branch)"
     output "  - Candidates: ${devbranches[*]}"
     for branch in "${devbranches[@]}"; do
-        if [ "${branch}" == "master" ]; then
-            # If there are multiple, master isn't ever the next one.
+        if [ "${branch}" == "main" ]; then
+            # If there are multiple, main isn't ever the next one.
             continue
         else
             # First one is the next one.
@@ -809,14 +809,14 @@ if [ $_type == "major" ] || [ $_type == "minor" ]; then
         if [ ${#devbranches[@]} -gt 1 ]; then
             echo "  - This has been a major release ${R}under parallel development${N}. It implies that the"
             echo "    STABLE branch released already existed, hence no new branch has been created by this tool."
-            echo "    - Important: If the parallel development period is going to continue with a new STABLE branch and master"
+            echo "    - Important: If the parallel development period is going to continue with a new STABLE branch and main"
             echo "      then, in few weeks, once the on-sync period ends, you will have to:"
             echo "      - Create the new MOODLE_XYZ_STABLE branch manually (branching from the STABLE branch just released)."
             echo "      - Modify all the related places needing to know about that new branch (security, CI, tracker, this tool config.sh..."
             echo "        (basically this implies to review all the Moodle Release Process check-list and perform all the"
             echo "        actions detailed there for a new branch - but without releasing it, heh, it's a dev branch!)."
             echo "    - If the parallel development period has ended, no further actions are needed, development will"
-            echo "      be back to normal, master-only"
+            echo "      be back to normal, main-only"
         else
             echo "  - As this was a major release you will need to ${R}update config.sh${N} to include the new stable branch as an expected branch."
         fi
@@ -826,7 +826,7 @@ if [ $_type == "major" ] || [ $_type == "minor" ]; then
     echo ""
 elif [ $_type == "on-sync" ]; then
     echo "${Y}Notes${N}: "
-    echo "  - Don't forget that ${R}the last week of on-sync${N} it's better to perform a ${R}normal master release (weekly)${N} in order to guarantee that versions have diverged. If this is such a week, please proceed accordingly."
+    echo "  - Don't forget that ${R}the last week of on-sync${N} it's better to perform a ${R}normal main release (weekly)${N} in order to guarantee that versions have diverged. If this is such a week, please proceed accordingly."
     echo "  - IMPORTANT: If this is ${R}the last week of on-sync${N}, don't forget to run all the actions that are documented together in the Point 1 of the \"2 weeks after\" section of the Moodle Release Process (link: https://docs.moodle.org/dev/Release_process#2_weeks_after). It is ${R}highly recommended to execute ALL the actions in that Point 1${N} immediately after moving out from on-sync (before the next week begins).${N}"
     echo ""
 elif [ $_type == "back-to-dev" ]; then

--- a/prerelease.sh
+++ b/prerelease.sh
@@ -50,7 +50,8 @@ devbranches=("${DEVBRANCHES[@]}");
 # Prepare an all branches array.
 OLDIFS="$IFS"
 IFS=$'\n'
-allbranches=($(for b in "${DEVBRANCHES[@]}" "${STABLEBRANCHES[@]}" "${SECURITYBRANCHES[@]}" ; do echo "$b" ; done | sort -du))
+# TODO: Remove master from the list once we delete it.
+allbranches=($(for b in master "${DEVBRANCHES[@]}" "${STABLEBRANCHES[@]}" "${SECURITYBRANCHES[@]}" ; do echo "$b" ; done | sort -du))
 IFS="$OLDIFS"
 
 in_array() {
@@ -192,6 +193,7 @@ bump_version() {
             return=1
         fi
     fi
+
     return $return;
 }
 
@@ -665,6 +667,8 @@ for branch in ${branches[@]};
         # Get the segment of the stable branch name to use for merges.
         stable=`expr "$branch" : 'MOODLE_'`
         mergestringsbranch="install_${branch:$stable}"
+        # TODO: Remove these 2 lines once AMOS starts generating the install_main branch.
+        mergestringsbranch="install_master"
     else
         # Must be a stable branch.
         # Stable branches are not included in major, beta, or rc releases.
@@ -762,6 +766,13 @@ for branch in ${branches[@]};
     fi
 
     if (( $newcommits > 0 )) ; then
+        # TODO: Delete these 7 lines (comments and if block) once we delete master.
+        # Ensure that, always, master is the same as main.
+        if [[ "${branch}" == "main" ]]; then
+            git branch -f master main
+            integrationpush="$integrationpush master"
+            output "  - ${Y}master branch updated to match main branch.${N}"
+        fi
         output "  + ${C}$branch done! $newcommits new commits to push.${N}"
         integrationpush="$integrationpush $branch"
     else

--- a/release.sh
+++ b/release.sh
@@ -18,7 +18,8 @@ fi
 # Prepare and array of all branches.
 OLDIFS="$IFS"
 IFS=$'\n'
-allbranches=($(for b in "${DEVBRANCHES[@]}" "${STABLEBRANCHES[@]}" "${SECURITYBRANCHES[@]}" ; do echo "$b" ; done | sort -du))
+# TODO: Remove master from the list once we delete it.
+allbranches=($(for b in master "${DEVBRANCHES[@]}" "${STABLEBRANCHES[@]}" "${SECURITYBRANCHES[@]}" ; do echo "$b" ; done | sort -du))
 IFS="$OLDIFS"
 
 # Reset to normal.


### PR DESCRIPTION
This enables integrators to start rolling to main and ensures that master is kept updated 100%.

Not much to say, the changes are just `s/master/main` changes and everything should start working with `main` without troubles.

And then, in a second commit, there are the changes that will ensure that we keep the old `master` branch fed with exactly the same commits than the new `main` branch and other small interim changes.

Note that the 2nd commit will be reverted once we finish the migration and the `master` branches have been deleted from all the repositories. Then, only the 1st commit will be needed.