### PR TITLE
Remove all references to bitbucket. Removed 20231128.

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,6 @@ As this involves pushing Moodle source code to the public git repositories we ma
 
 * git://git.moodle.org/moodle.git
 * git@github.com:moodle/moodle.git
-* git@bitbucket.org:moodle/moodle.git
 
 Installation
 ------------

--- a/install.sh
+++ b/install.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # This scripts prepares git checkout necessary for the prerelease and release.sh scripts
-# Please note you need to have public ssh key in all the remotes below (github,  bitbucket)
+# Please note you need to have public ssh key in all the remotes below (github)
 # And also, can decide about the protocol (ssh, https) to be used against moodle main repositories.
 
 # Include config to get access to branch information.
@@ -73,7 +73,6 @@ git remote set-url --push origin ${remotei}
 git remote add public ${remotem}
 git remote set-url --add --push public ${remotem}
 git remote set-url --add --push public git@github.com:moodle/moodle.git
-git remote set-url --add --push public git@bitbucket.org:moodle/moodle.git
 
 # Create stable branches with the upstream set.
 for branch in ${STABLEBRANCHES[@]}; do

--- a/release.sh
+++ b/release.sh
@@ -195,7 +195,6 @@ fi
 # Update public repositories
 #  * moodle         - git://git.moodle.org/moodle.git
 #  * github         - git@github.com:moodle/moodle.git
-#  * bitbucket      - git@bitbucket.org:moodle/moodle.git
 git push ${pushargs} public ${pushbranches[@]}
 
 output "${G}Done!${N}"


### PR DESCRIPTION
Simply remove any reference to bitbucket @:
- Docs.
- Comments.
- Install.

Note that everybody will need, once this is merged, to:

- Update local clone with latest changes (including this PR).
- Execute: 
  ```
  cd gitmirror
  git remote set-url --delete --push public git@bitbucket.org:moodle/moodle.git
  ```
- Then, verify that there isn't any "bitbucket" anymore in the "public" remote by executing: `git remote -v` (only git.in.moodle.com (our gitlab canonical repo) and github.com remotes should remain into "public").