### PR TITLE
Packaging times awareness

### DIFF
--- a/config.sh
+++ b/config.sh
@@ -11,3 +11,11 @@ STABLEBRANCHES=('MOODLE_404_STABLE' 'MOODLE_403_STABLE')
 
 # Current security branches. (Later versions first)
 SECURITYBRANCHES=('MOODLE_402_STABLE' 'MOODLE_401_STABLE')
+
+# UTC time when the publishing will be done. Keep this in sync with the downloads publishing time.
+PUBLISHING_TIME='00:50:00'
+
+# Time in minutes (before PUBLISHING_TIME) that we consider not advisable to start with pre-release tasks,
+# because any delay with them may clash with the downloads publishing time, leading to some packages
+# not being properly published. See MDLSITE-7681 for more details.
+PREVENT_MINUTES='60'

--- a/lib.sh
+++ b/lib.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+# Library of functions and variables shared by various scripts.
+# Note that this needs to be sourced to work correctly.
+
+# Include config to get access to branch information.
+if [ -f "$(dirname "${0}")"/config.sh ]; then
+    source "$(dirname "${0}")"/config.sh
+else
+    echo "Unable to include config.sh"
+    exit 1
+fi
+
+# A few colours for output.
+# Reset to normal.
+N="$(tput sgr0)"
+# Red.
+R="$(tput setaf 1)"
+# Green.
+G="$(tput setaf 2)"
+# Yellow.
+Y="$(tput setaf 3)"
+# Cyan.
+C="$(tput setaf 6)"
+# Bold.
+bold="$(tput bold)"
+# Normal.
+normal="$(tput sgr0)"
+
+# The base dir
+mydir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+git_last_commit_hash() {
+    git log --pretty=format:'%H' -n 1
+    return 0
+}
+
+# To output anything from the scripts (content and, optionally, no line break).
+output() {
+    if $_verbose; then
+        if [ -n "${2}" ]; then
+            echo -n "${1}"
+        else
+            echo "${1}"
+        fi
+    fi
+}

--- a/lib.sh
+++ b/lib.sh
@@ -44,3 +44,17 @@ output() {
         fi
     fi
 }
+
+# Given a UTC time in the HH:MM:SS format, returns the next unix seconds
+# when it will be that UTC time.
+function next_utc_time() {
+    local time="${1}" # Time in HH:MM:SS format.
+    local now         # Current time in seconds.
+    local next        # To calculate the next time in seconds.
+    now=$(date -u +%s)
+    next=$(date -u -d "$(date -u -d @"${now}" +"%Y-%m-%d $time")" +%s)
+    if [ "${now}" -gt "${next}" ]; then # If the time has already passed today.
+        next=$(date -u -d "$(date -u -d @"${next}") +1 day" +%s)
+    fi
+    echo "${next}" # Return the next time in seconds.
+}

--- a/prerelease.sh
+++ b/prerelease.sh
@@ -482,6 +482,26 @@ if $_showhelp ; then
     show_help
 fi
 
+# Before anything else, let's check if, right now, it's a good time to run this script.
+
+# Calculate a few timestamps (unix seconds since epoch).
+curr=$(date -u +%s) # Now
+publ=$(next_utc_time "${PUBLISHING_TIME}") # Publishing time UTC.
+
+# Calculate some local and interval times.
+publlocal=$(date -d @"${publ}" +'%H:%M:%S %Z')    # Publishing time in local time.
+prevention=$((publ - PREVENT_MINUTES * 60))       # Begin of prevention time.
+
+# If we are within the prevention time, let's prevent and exit.
+if [ "${curr}" -gt "${prevention}" ]; then
+    output "${Y}The packaging server is about to start processing git changes${N}"
+    output "${Y}and it is not advisable to run this script while that happens.${N}"
+    output ""
+    output "${Y}Please wait until everything has been executed after ${PUBLISHING_TIME} UTC (${publlocal}).${N}"
+    output "${R}Exiting.${N}"
+    exit 1
+fi
+
 if [[ ! -d ${mydir}/gitmirror ]] ; then
     output "Directory ${mydir}/gitmirror not found. You may need to create it with install.sh"
     exit 1

--- a/prerelease.sh
+++ b/prerelease.sh
@@ -1,26 +1,14 @@
 #!/bin/bash
 # This script performs required pre-release processing.
 
-# Include config to get access to branch information.
-if [ -f $(dirname $0)/config.sh ]; then
-    source $(dirname $0)/config.sh
+# Include lib.sh to get access to shared stuff..
+if [ -f "$(dirname "${0}")"/lib.sh ]; then
+    source "$(dirname "${0}")"/lib.sh
 else
-    echo "Unable to include config.sh"
+    echo "Unable to include lib.sh"
     exit 1
 fi
 
-# Reset to normal.
-N="$(tput sgr0)"
-# Red.
-R="$(tput setaf 1)"
-# Green.
-G="$(tput setaf 2)"
-# Yellow.
-Y="$(tput setaf 3)"
-# Cyan.
-C="$(tput setaf 6)"
-# This script base dir
-mydir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 # The branches to push to integration.
 integrationpush=""
 
@@ -247,11 +235,7 @@ get_new_stable_branch() {
     fi
     echo "MOODLE_${first}${second}_STABLE"
 }
-output() {
-    if $_verbose ; then
-        echo "$1"
-    fi
-}
+
 show_help() {
     bold=`tput bold`
     normal=`tput sgr0`

--- a/release.sh
+++ b/release.sh
@@ -7,11 +7,11 @@
 #
 # This script base dir
 
-# Include config to get access to branch information.
-if [ -f $(dirname $0)/config.sh ]; then
-    source $(dirname $0)/config.sh
+# Include lib.sh to get access to shared stuff..
+if [ -f "$(dirname "${0}")"/lib.sh ]; then
+    source "$(dirname "${0}")"/lib.sh
 else
-    echo "Unable to include config.sh"
+    echo "Unable to include lib.sh"
     exit 1
 fi
 
@@ -22,18 +22,6 @@ IFS=$'\n'
 allbranches=($(for b in master "${DEVBRANCHES[@]}" "${STABLEBRANCHES[@]}" "${SECURITYBRANCHES[@]}" ; do echo "$b" ; done | sort -du))
 IFS="$OLDIFS"
 
-# Reset to normal.
-N="$(tput setaf 9)"
-# Red.
-R="$(tput setaf 1)"
-# Green.
-G="$(tput setaf 2)"
-# Yellow.
-Y="$(tput setaf 3)"
-# Cyan.
-C="$(tput setaf 6)"
-bold=`tput bold`
-normal=`tput sgr0`
 _verbose=true # Make lots of noise.
 _showhelp=false
 _confirmed=false
@@ -76,16 +64,6 @@ show_help() {
     echo ""
     echo "May the --force be with you"
     exit 0;
-}
-
-output() {
-    if $_verbose ; then
-        if [ ! -z $2 ]  ; then
-            echo -n "$1"
-        else
-            echo "$1"
-        fi
-    fi
 }
 
 while test $# -gt 0;


### PR DESCRIPTION
 First commit:

We are going to need some function to be available
for both the prerelease.sh and the release.sh scripts
so let's move some methods and variables to it (`lib.sh`).

Second commit:

See [MDLSITE-7681](https://tracker.moodle.org/browse/MDLSITE-7681) for more details

Basically this prevents `prerelease.sh` to be executed
when we are 60 minutes (configurable) before the packages
publishing happen in the server at 00:50 UTC (configurable).

That's to avoid any problem with both running together
and potentially leading to some weekly versions not being
ever published.

So the script now detects if the server is close to run
the publishing scripts and exits with error, recommending to try
again once the server has finished.

The message is as follows:

```
$ ./prerelease.sh 
The packaging server is about to start processing git changes
and it is not advisable to run this script while that happens.

Please wait until everything has been executed after 00:50:00 UTC (02:50:00 CEST).
```

Important note, this only implements the check in the `prerelease.sh` script (and that should be enough 99.99% of times), there will one more, final, check in the `release.sh` script but will be part of another PR.

Just sending this one in advance to 1) be already protected and 2) introduce the `lib.sh` script that maybe interesting to have for some new features of the tool (new changelogs).

Ciao :-)
