### PR TITLE
Some operations can fail if the date/time is not the expected one

### DIFF
--- a/lib.sh
+++ b/lib.sh
@@ -63,10 +63,10 @@ function next_utc_time() {
     local time="${1}" # Time in HH:MM:SS format.
     local now         # Current time in seconds.
     local next        # To calculate the next time in seconds.
-    now=$(date -u +%s)
-    next=$(date -u -d "$(date -u -d @"${now}" +"%Y-%m-%d $time")" +%s)
+    now=$(LC_ALL=C date -u +%s)
+    next=$(LC_ALL=C date -u -d "$(LC_ALL=C date -u -d @"${now}" +"%Y-%m-%d $time")" +%s)
     if [ "${now}" -gt "${next}" ]; then # If the time has already passed today.
-        next=$(date -u -d "$(date -u -d @"${next}") +1 day" +%s)
+        next=$(LC_ALL=C date -u -d "$(LC_ALL=C date -u -d @"${next}") +1 day" +%s)
     fi
     echo "${next}" # Return the next time in seconds.
 }

--- a/prerelease.sh
+++ b/prerelease.sh
@@ -513,11 +513,11 @@ fi
 # Before anything else, let's check if, right now, it's a good time to run this script.
 
 # Calculate a few timestamps (unix seconds since epoch).
-curr=$(date -u +%s) # Now
+curr=$(LC_ALL=C date -u +%s) # Now
 publ=$(next_utc_time "${PUBLISHING_TIME}") # Publishing time UTC.
 
 # Calculate some local and interval times.
-publlocal=$(date -d @"${publ}" +'%H:%M:%S %Z')    # Publishing time in local time.
+publlocal=$(LC_ALL=C date -d @"${publ}" +'%H:%M:%S %Z')    # Publishing time in local time.
 prevention=$((publ - PREVENT_MINUTES * 60))       # Begin of prevention time.
 
 # If we are within the prevention time, let's prevent and exit.

--- a/release.sh
+++ b/release.sh
@@ -132,9 +132,9 @@ for b in "${allbranches[@]}" ; do
         # We very-rarely should face this, as far as the pre-release script already detects
         # 99% of cases, but this is a last-resort check.
         comm=$(git log -n1 --pretty=format:"%ct" origin/"${b}") # Last commit time in seconds.
-        curr=$(date -u +%s)                            # Now in seconds.
-        publ=$(date -u -d "${PUBLISHING_TIME}" +%s)    # Publishing time in seconds.
-        publlocal=$(date -d @"${publ}" +'%H:%M:%S %Z') # Publishing time in local time.
+        curr=$(LC_ALL=C date -u +%s)                            # Now in seconds.
+        publ=$(LC_ALL=C date -u -d "${PUBLISHING_TIME}" +%s)    # Publishing time in seconds.
+        publlocal=$(LC_ALL=C date -d @"${publ}" +'%H:%M:%S %Z') # Publishing time in local time.
 
         if [ "${comm}" -lt "${publ}" ] && [ "${curr}" -gt "${publ}" ]; then
             output "  ${Y}Between the last commit and now, the packaging server${N}"


### PR DESCRIPTION
Basically, when using english, it works ok (en_US, en_AU.UTF-8, ...) but can fail with some collations like es_ES.UTf-8 when making some calculations because the expected formats are different from what the collation provides.

So, we are going to use LC_ALL=C in all the "date" commands used by the scripts in order to provide a consistent behaviour no matter which collation is being used by default.

We could also have set LC_TIME, LANG... but as far as LC_ALL is the one with max precedence, we just set that one, and only for the execution of the "date" commands. And "C", because that is the default, basic collation that all the systems support much like the POSIX one, only ASCII and enough for our interests).